### PR TITLE
 Check if AX_CHECK_COMPILE_FLAG is available or print error 

### DIFF
--- a/accflags.m4
+++ b/accflags.m4
@@ -1,7 +1,9 @@
 AC_DEFUN([NEARD_COMPILER_FLAGS], [
 	# AX_CHECK_COMPILE_FLAG comes from autoconf-archive
 	AC_REQUIRE([AC_PROG_CC])
-	AC_REQUIRE([AX_CHECK_COMPILE_FLAG])
+	m4_ifndef([AX_CHECK_COMPILE_FLAG],[
+		AC_MSG_ERROR([You need to install the autoconf-archive package.])
+	])
 
 	if (test "${CFLAGS}" = ""); then
 		CFLAGS="-Wall -O2 -D_FORTIFY_SOURCE=2"


### PR DESCRIPTION
- Change AC_HELP_STRING obsolete macro with AS_HELP_STRING
- Remove AX_CHECK_COMPILE_FLAG warning by checking if available or fail
- Other minor fixes

~~~
$ autoreconf -ivf --warnings=all
(...)
aclocal: warning: couldn't open directory 'm4': No such file or directory
configure.ac:43: warning: AX_CHECK_COMPILE_FLAG is m4_require'd but not m4_defun'd
accflags.m4:1: NEARD_COMPILER_FLAGS is expanded from...
configure.ac:43: the top level
configure.ac:43: warning: AX_CHECK_COMPILE_FLAG is m4_require'd but not m4_defun'd
accflags.m4:1: NEARD_COMPILER_FLAGS is expanded from...
configure.ac:43: the top level
autoreconf: configure.ac: tracing
configure.ac:43: warning: AX_CHECK_COMPILE_FLAG is m4_require'd but not m4_defun'd
accflags.m4:1: NEARD_COMPILER_FLAGS is expanded from...
configure.ac:43: the top level
(...)
configure.ac:112: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:112: You should run autoupdate.
../../lib/autoconf/general.m4:207: AC_HELP_STRING is expanded from...
configure.ac:112: the top level
configure.ac:126: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:126: You should run autoupdate.
../../lib/autoconf/general.m4:207: AC_HELP_STRING is expanded from...
configure.ac:126: the top level
configure.ac:140: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:140: You should run autoupdate.
../../lib/autoconf/general.m4:207: AC_HELP_STRING is expanded from...
configure.ac:140: the top level
(...)
~~~