### PR TITLE
build: install org.neard.se.conf dbus configuration file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -111,6 +111,10 @@ dbusdir = ${sysconfdir}/dbus-1/system.d/
 
 dist_dbus_DATA = src/org.neard.conf
 
+if SE
+dist_dbus_DATA += se/org.neard.se.conf
+endif
+
 if MAINTAINER_MODE
 
 if SE


### PR DESCRIPTION
Without this attempting to launch `seeld` as root resulted in:
```
Connection ":1.0" is not allowed to own the service "org.neard.se" due to security policies in the configuration file
```