### PR TITLE
Added tag uid api to DBUS interface 

### DIFF
--- a/doc/tag-api.txt
+++ b/doc/tag-api.txt
@@ -54,6 +54,9 @@ Properties	string Type [readonly]
 
 			The object path of the adapter the tag belongs to.
 
+        array{byte} Uid [readonly]
+
+			The NFC tag UID.
 
 Record hierarchy
 ================

--- a/src/tag.c
+++ b/src/tag.c
@@ -169,7 +169,7 @@ static const char *type_string(struct near_tag *tag)
 	return type;
 }
 
-static const uint8_t uid_array(struct near_tag *tag, uint8_t **uid)
+static uint8_t uid_array(struct near_tag *tag, uint8_t **uid)
 {
 	if (tag->nfcid_len) {
 		DBG("NFCID: ");


### PR DESCRIPTION
- Added a tag property to get the UID;
- Updated tag-api documentation;
- Tested with a TI trf7970a.

The code modifications are from https://lore.kernel.org/linux-nfc/20210311085020.429987-1-frieder.schrempf@kontron.de/T/