### PR TITLE
Fix a parallel compilation issue

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -248,6 +248,7 @@ SED_PROCESS = $(AM_V_GEN)$(MKDIR_P) $(dir $@) && \
 src/plugin.$(OBJEXT): src/builtin.h
 
 src/builtin.h: src/genbuiltin $(builtin_sources)
+	$(AM_V_at)$(MKDIR_P) src
 	$(AM_V_GEN)$(srcdir)/src/genbuiltin $(builtin_modules) > $@
 
 se/plugin.$(OBJEXT): se/builtin.h


### PR DESCRIPTION
Fix the `src/builtin.h` running before the `src` directory is created. 

Patch fix is from [openembedded-core](https://github.com/openembedded/openembedded-core/blob/master/meta/recipes-connectivity/neard/neard/Makefile.am-fix-parallel-issue.patch).