### PR TITLE
Docs Only  - Provide packages needed for library and Code Formatting

### DIFF
--- a/README
+++ b/README
@@ -59,16 +59,13 @@ Bugs and contributing
 ----------------------------
 
 Please send bug reports to mailing list:
-	linux-nfc@lists.01.org
+  [linux-nfc@lists.01.org](mailto:linux-nfc@lists.01.org)
 
 The project development happens on GitHub:
-	https://github.com/linux-nfc/neard
+  [https://github.com/linux-nfc/neard](https://github.com/linux-nfc/neard)
 
-However for historical reasons the releases are also mirrored on kernel.org
-repository:
-	https://git.kernel.org/pub/scm/network/nfc/neard.git/
+  [https://git.kernel.org/pub/scm/network/nfc/neard.git/](https://git.kernel.org/pub/scm/network/nfc/neard.git/)
 
-Contributions can come in a form of patches sent to linux-nfc@lists.01.org or
-GitHub pull requests on mentioned GitHub repository.
+Contributions can come in a form of patches sent to [linux-nfc@lists.01.org](mailto:linux-nfc@lists.01.org) or GitHub pull requests on mentioned GitHub repository.
 
-See also HACKING and doc/coding-style.txt files.
+See also [HACKING](HACKING) and [doc/coding-style.txt](doc/coding-style.txt) files.

--- a/README
+++ b/README
@@ -1,11 +1,11 @@
 Near Field Communication manager
-********************************
+============================
 
 Copyright (C) 2011  Intel Corporation. All rights reserved.
 
 
 Compilation and installation
-============================
+----------------------------
 
 In order to compile neard you need following software packages:
 	- GCC compiler
@@ -22,7 +22,7 @@ To compile and install run:
 	make && make install
 
 Configuration and options
-=========================
+----------------------------
 
 By default all neard plugins and features are built in. They can be
 disabled with the following configuration options:
@@ -56,7 +56,7 @@ run it, with maintainer mode enabled. bootstrap-configure will configure
 neard with all features enabled.
 
 Bugs and contributing
-=====================
+----------------------------
 
 Please send bug reports to mailing list:
 	linux-nfc@lists.01.org

--- a/README
+++ b/README
@@ -8,10 +8,34 @@ Compilation and installation
 ----------------------------
 
 In order to compile neard you need following software packages:
-	- GCC compiler
-	- D-Bus library
-	- GLib library
-	- Netlink (libnl) library, version 1 or 2.
+
+  <details>
+  <summary>GCC compiler</summary>
+
+  - Ubuntu - `gcc`
+
+  </details>
+
+  <details>
+  <summary>D-Bus library</summary>
+
+  - Ubuntu - `libdbus-1-dev`
+
+  </details>
+
+  <details>
+  <summary>GLib library</summary>
+
+  - Ubuntu - `libglib2.0-dev`
+
+  </details>
+
+  <details>
+  <summary>Netlink (libnl) library, version 1 or 2.</summary>
+
+  - Ubuntu - `libnl-3-dev`
+
+  </details>
 
 To configure run:
 

--- a/README
+++ b/README
@@ -57,8 +57,7 @@ disabled with the following configuration options:
 
 		Disable support for peer to peer mode.
 
-Running `./bootstrap-configure` will build the configure script and then
-run it, with maintainer mode enabled. `bootstrap-configure` will configure neard with all features enabled.
+Running `./bootstrap-configure` will build the configure script and then run it, with maintainer mode enabled. `bootstrap-configure` will configure neard with all features enabled.
 
 Bugs and contributing
 ----------------------------
@@ -69,6 +68,7 @@ Please send bug reports to mailing list:
 The project development happens on GitHub:
   [https://github.com/linux-nfc/neard](https://github.com/linux-nfc/neard)
 
+However for historical reasons the releases are also mirrored on kernel.org repository:
   [https://git.kernel.org/pub/scm/network/nfc/neard.git/](https://git.kernel.org/pub/scm/network/nfc/neard.git/)
 
 Contributions can come in a form of patches sent to [linux-nfc@lists.01.org](mailto:linux-nfc@lists.01.org) or GitHub pull requests on mentioned GitHub repository.

--- a/README
+++ b/README
@@ -3,7 +3,6 @@ Near Field Communication manager
 
 Copyright (C) 2011  Intel Corporation. All rights reserved.
 
-
 Compilation and installation
 ----------------------------
 
@@ -37,13 +36,13 @@ In order to compile neard you need following software packages:
 
   </details>
 
-To configure run:
+Running `./bootstrap-configure` will build the configure script and then run it, with maintainer mode enabled. `bootstrap-configure` will configure neard with all features enabled.
 
-```bash
+To configure and automatically searches for all required components and packages run:
+
+  ```bash
   ./configure --prefix=/usr
-```
-
-Configure automatically searches for all required components and packages.
+  ```
 
 To compile and install run:
 
@@ -65,8 +64,6 @@ By default all neard plugins and features are built in. They can be
 | `--disable-nfctype4`  | Disable support for type 4 NFC tags.       |
 | `--disable-nfctype5`  | Disable support for type 5 ISO 15693 tags. |
 | `--disable-p2p`       | Disable support for peer to peer mode.     |
-
-Running `./bootstrap-configure` will build the configure script and then run it, with maintainer mode enabled. `bootstrap-configure` will configure neard with all features enabled.
 
 Bugs and contributing
 ----------------------------

--- a/README
+++ b/README
@@ -31,31 +31,16 @@ Configuration and options
 ----------------------------
 
 By default all neard plugins and features are built in. They can be
-disabled with the following configuration options:
+**disabled** with the following configuration options:
 
-	--disable-nfctype1
-
-		Disable support for type 1 NFC tags.
-
-	--disable-nfctype2
-
-		Disable support for type 2 NFC tags.
-
-	--disable-nfctype3
-
-		Disable support for type 3 NFC tags.
-
-	--disable-nfctype4
-
-		Disable support for type 1 NFC tags.
-
-	--disable-nfctype5
-
-		Disable support for type 5 ISO 15693 tags.
-
-	--disable-p2p
-
-		Disable support for peer to peer mode.
+| Option                | Description                                |
+| --------------------- | ------------------------------------------ |
+| `--disable-nfctype1`  | Disable support for type 1 NFC tags.       |
+| `--disable-nfctype2`  | Disable support for type 2 NFC tags.       |
+| `--disable-nfctype3`  | Disable support for type 3 NFC tags.       |
+| `--disable-nfctype4`  | Disable support for type 4 NFC tags.       |
+| `--disable-nfctype5`  | Disable support for type 5 ISO 15693 tags. |
+| `--disable-p2p`       | Disable support for peer to peer mode.     |
 
 Running `./bootstrap-configure` will build the configure script and then run it, with maintainer mode enabled. `bootstrap-configure` will configure neard with all features enabled.
 

--- a/README
+++ b/README
@@ -14,12 +14,18 @@ In order to compile neard you need following software packages:
 	- Netlink (libnl) library, version 1 or 2.
 
 To configure run:
-	./configure --prefix=/usr
+
+```bash
+  ./configure --prefix=/usr
+```
 
 Configure automatically searches for all required components and packages.
 
 To compile and install run:
-	make && make install
+
+  ```bash
+  make && make install
+  ```
 
 Configuration and options
 ----------------------------
@@ -51,9 +57,8 @@ disabled with the following configuration options:
 
 		Disable support for peer to peer mode.
 
-Running ./bootstrap-configure will build the configure script and then
-run it, with maintainer mode enabled. bootstrap-configure will configure
-neard with all features enabled.
+Running `./bootstrap-configure` will build the configure script and then
+run it, with maintainer mode enabled. `bootstrap-configure` will configure neard with all features enabled.
 
 Bugs and contributing
 ----------------------------


### PR DESCRIPTION
Just a minor docs update to help users determine which packages provide the needed libraries for neard, rather than search though package repositories. Also added code coloring for bash scripts and links for appropriate linkable resources. 