### PR TITLE
ci: Update distro versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,18 +34,18 @@ jobs:
           - archlinux:latest
           - debian:testing
           - debian:stable
+          - debian:forky
           - debian:trixie
           - debian:bookworm
-          - debian:bullseye
           # Fails on configure on GCC and clang (process restrictions?)
           # - fedora:rawhide
           - fedora:latest
-          - fedora:42
-          - fedora:41
+          - fedora:44
+          - fedora:43
           - ubuntu:latest
+          - ubuntu:resolute
           - ubuntu:noble
           - ubuntu:jammy
-          - ubuntu:focal
         cross_compile: [""]
         mode: [maintainer, no-maintainer]
         variant: [""]
@@ -93,28 +93,28 @@ jobs:
             mode: no-maintainer
             variant: i386
 
-          - container: "debian:bookworm"
+          - container: "debian:forky"
             arch: i386
             compiler: gcc -m32
             cross_compile: i686-linux-gnu
             mode: maintainer
             variant: i386
 
-          - container: "debian:bookworm"
+          - container: "debian:forky"
             arch: i386
             compiler: gcc -m32
             cross_compile: i686-linux-gnu
             mode: no-maintainer
             variant: i386
 
-          - container: "debian:bullseye"
+          - container: "debian:bookworm"
             arch: i386
             compiler: gcc -m32
             cross_compile: i686-linux-gnu
             mode: maintainer
             variant: i386
 
-          - container: "debian:bullseye"
+          - container: "debian:bookworm"
             arch: i386
             compiler: gcc -m32
             cross_compile: i686-linux-gnu
@@ -178,20 +178,6 @@ jobs:
             mode: maintainer
             variant: cross-compile
 
-          - container: "debian:bullseye"
-            arch: armhf
-            compiler: arm-linux-gnueabihf-gcc
-            cross_compile: arm-linux-gnueabihf
-            mode: maintainer
-            variant: cross-compile
-
-          - container: "debian:bullseye"
-            arch: arm64
-            compiler: aarch64-linux-gnu-gcc
-            cross_compile: aarch64-linux-gnu
-            mode: maintainer
-            variant: cross-compile
-
           # Debian GCC sanitizer builds
           - container: "debian:testing"
             arch: x86-64
@@ -211,13 +197,13 @@ jobs:
             mode: maintainer
             variant: sanitizers
 
-          - container: "debian:bookworm"
+          - container: "debian:forky"
             arch: x86-64
             compiler: gcc
             mode: maintainer
             variant: sanitizers
 
-          - container: "debian:bullseye"
+          - container: "debian:bookworm"
             arch: x86-64
             compiler: gcc
             mode: maintainer
@@ -238,6 +224,20 @@ jobs:
             mode: no-maintainer
             variant: i386
 
+          - container: "ubuntu:resolute"
+            arch: i386
+            compiler: gcc -m32
+            cross_compile: i686-linux-gnu
+            mode: maintainer
+            variant: i386
+
+          - container: "ubuntu:resolute"
+            arch: i386
+            compiler: gcc -m32
+            cross_compile: i686-linux-gnu
+            mode: no-maintainer
+            variant: i386
+
           - container: "ubuntu:noble"
             arch: i386
             compiler: gcc -m32
@@ -260,20 +260,6 @@ jobs:
             variant: i386
 
           - container: "ubuntu:jammy"
-            arch: i386
-            compiler: gcc -m32
-            cross_compile: i686-linux-gnu
-            mode: no-maintainer
-            variant: i386
-
-          - container: "ubuntu:focal"
-            arch: i386
-            compiler: gcc -m32
-            cross_compile: i686-linux-gnu
-            mode: maintainer
-            variant: i386
-
-          - container: "ubuntu:focal"
             arch: i386
             compiler: gcc -m32
             cross_compile: i686-linux-gnu
@@ -287,6 +273,12 @@ jobs:
             mode: maintainer
             variant: sanitizers
 
+          - container: "ubuntu:resolute"
+            arch: x86-64
+            compiler: gcc
+            mode: maintainer
+            variant: sanitizers
+
           - container: "ubuntu:noble"
             arch: x86-64
             compiler: gcc
@@ -294,12 +286,6 @@ jobs:
             variant: sanitizers
 
           - container: "ubuntu:jammy"
-            arch: x86-64
-            compiler: gcc
-            mode: maintainer
-            variant: sanitizers
-
-          - container: "ubuntu:focal"
             arch: x86-64
             compiler: gcc
             mode: maintainer


### PR DESCRIPTION
Update debian, fedora and ubuntu to their latest version available, remove unsupported versions.